### PR TITLE
remove properties, api does not use it anymore

### DIFF
--- a/pages/error_page.json
+++ b/pages/error_page.json
@@ -1,3 +1,2 @@
 {
-  "enabled": true
 }


### PR DESCRIPTION
See #8 , API was updated on enabled is not used anymore. This result in a warning in the extension logs.